### PR TITLE
Recovery in rf522.Wait

### DIFF
--- a/rf522/Rf522.go
+++ b/rf522/Rf522.go
@@ -344,6 +344,11 @@ func (r *RFID) Request() (backBits int, err error) {
 func (r *RFID) Wait() (err error) {
 	irqChannel := make(chan bool)
 	r.IrqPin.BeginWatch(gpio.EdgeFalling, func() {
+		defer func(){
+			if recover() != nil {
+				err = errors.New("panic")
+			}
+		}()
 		irqChannel <- true
 	})
 


### PR DESCRIPTION
Hello, thank you for the library, everything works great. 

The only things is that during the `rf522.Wait()` sometimes it's panicing due to closed channel. It seems, that even though `r.IrqPin.EndWatch()` is called, once in a while gpio lib still calls callback for some reason. 

Probably it makes sense to look at the root cause, but at least as a quick workaround we can patch it on a rf522 level.